### PR TITLE
feat: implement summary

### DIFF
--- a/src/getClassSummary.ts
+++ b/src/getClassSummary.ts
@@ -1,0 +1,41 @@
+export const getClassSummary = async (cookie: string, leaderboard: any) => {
+  /* Object from stats
+  {
+    firstName,
+    lastName,
+    username,
+    memberProfileUrl,
+    daysEnrolled,
+    badges,
+    agons,
+    goodDeedCheckins,
+    goodDeedPercentage,
+    fitnessCheckins,
+    fitnessPercentage,
+  }
+  */
+  const summaryStats = {
+    badgesCount: 0,
+    badgesPercentage: 0,
+    agonsCount: 0,
+    agonsPercentage: 0,
+    deedsCount: 0,
+    goodDeedPercentage: 0,
+    fitnessCount: 0,
+    fitnessPercentage: 0,
+    passing: 0,
+  };
+
+  const blacklist = ['@ibrew4u', '@brettmckay', '@tntbuff', '@michael', '@brian-prahm'];
+
+  for (const member of leaderboard) {
+    if (blacklist.includes(member.username)) continue;
+    summaryStats.badgesCount = member.badges > 0 ? summaryStats.badgesCount + 1 : summaryStats.badgesCount;
+    summaryStats.agonsCount = member.agons > 6 ? summaryStats.agonsCount + 1 : summaryStats.agonsCount;
+    summaryStats.deedsCount = member.goodDeedPercentage >= 75.0 ? summaryStats.deedsCount + 1 : summaryStats.deedsCount;
+    summaryStats.fitnessCount = member.fitnessPercentage >= 75.0 ? summaryStats.fitnessCount + 1 : summaryStats.fitnessCount;
+    if (member.badges > 0 && member.agons > 6 && member.goodDeedPercentage >= 75.0 && member.fitnessPercentage >= 75.0) summaryStats.passing++;
+  }
+
+  return summaryStats;
+};

--- a/src/indexTemplate.ts
+++ b/src/indexTemplate.ts
@@ -49,12 +49,14 @@ export const indexTemplate = `<html>
     <h1>Class Summary - Number Of Cards Passing</h1>
     <table id="class-table-id">
       <thead class="heading">
+        <th class="name">Fully Passing&nbsp;</td>
         <th class="name">Badges&nbsp;</td>
         <th class="name">Agons&nbsp;</td>
         <th class="name">Good Deeds&nbsp;</td>
         <th class="number">Fitness&nbsp;</td>
       </thead>
         <tr>
+          <td class="name"><%= data.class.passing %></td>
           <td class="name"><%= data.class.badgesCount %></td>
           <td class="name"><%= data.class.agonsCount %></td>
           <td class="number"><%= data.class.deedsCount %></td>

--- a/src/indexTemplate.ts
+++ b/src/indexTemplate.ts
@@ -46,6 +46,21 @@ export const indexTemplate = `<html>
     </style>
   </head>
   <body>
+    <h1>Class Summary - Number Of Cards Passing</h1>
+    <table id="class-table-id">
+      <thead class="heading">
+        <th class="name">Badges&nbsp;</td>
+        <th class="name">Agons&nbsp;</td>
+        <th class="name">Good Deeds&nbsp;</td>
+        <th class="number">Fitness&nbsp;</td>
+      </thead>
+        <tr>
+          <td class="name"><%= data.class.badgesCount %></td>
+          <td class="name"><%= data.class.agonsCount %></td>
+          <td class="number"><%= data.class.deedsCount %></td>
+          <td class="number"><%= data.class.fitnessCount%></td>
+        </tr>
+    </table>
     <h1>Leaderboard</h1>
     <table id="table-id">
       <thead class="heading">
@@ -60,18 +75,18 @@ export const indexTemplate = `<html>
         <th class="number">Fitness Chk-ins&nbsp;</td>
         <th class="number">Fitness %&nbsp;</td>
       </thead>
-      <% for (let i = 0; i < data.length; i++) { %>
+      <% for (let i = 0; i < data.leaderboard.length; i++) { %>
         <tr>
-          <td class="name"><%= data[i].lastName %></td>
-          <td class="name"><%= data[i].firstName %></td>
-          <td class="name"><a href="<%= data[i].memberProfileUrl %>">@<%= data[i].username %></a></td>
-          <td class="number"><%= data[i].daysEnrolled %></td>
-          <td class="number"><%= data[i].badges %></td>
-          <td class="number"><%= data[i].agons%></td>
-          <td class="number"><%= data[i].goodDeedCheckins %></td>
-          <td class="number"><%= data[i].goodDeedPercentage %></td>
-          <td class="number"><%= data[i].fitnessCheckins %></td>
-          <td class="number"><%= data[i].fitnessPercentage %></td>
+          <td class="name"><%= data.leaderboard[i].lastName %></td>
+          <td class="name"><%= data.leaderboard[i].firstName %></td>
+          <td class="name"><a href="<%= data.leaderboard[i].memberProfileUrl %>">@<%= data.leaderboard[i].username %></a></td>
+          <td class="number"><%= data.leaderboard[i].daysEnrolled %></td>
+          <td class="number"><%= data.leaderboard[i].badges %></td>
+          <td class="number"><%= data.leaderboard[i].agons%></td>
+          <td class="number"><%= data.leaderboard[i].goodDeedCheckins %></td>
+          <td class="number"><%= data.leaderboard[i].goodDeedPercentage %></td>
+          <td class="number"><%= data.leaderboard[i].fitnessCheckins %></td>
+          <td class="number"><%= data.leaderboard[i].fitnessPercentage %></td>
         </tr>
       <% } %>
     </table>

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,13 +3,22 @@ import { minify } from 'html-minifier';
 import template from 'lodash/template';
 import * as path from 'path';
 import { getAllStats } from './getAllStats';
+import { getClassSummary } from './getClassSummary';
 import { getLeaderboard } from './getLeaderboard';
 import { indexTemplate } from './indexTemplate';
 
 export const run = async () => {
+  const data = {
+    leaderboard: null,
+    class: null,
+  };
   const cookie = process.env.TSL_COOKIE;
   const leaderboard = await getLeaderboard(cookie);
-  const data = await getAllStats(cookie, leaderboard);
+  data.leaderboard = await getAllStats(cookie, leaderboard);
+  data.class = await getClassSummary(cookie, data.leaderboard);
+  if (process.env.SAVE_RAW_DATA != undefined) {
+    fs.writeFileSync(path.resolve(__dirname, '..', 'data.json'), JSON.stringify(data));
+  }
   const compiled = template(indexTemplate);
   const htmlRaw = compiled({ data });
   const minified = minify(htmlRaw, { minifyCSS: true, collapseWhitespace: true });


### PR DESCRIPTION
Adds a summary table to the top of the leaderboard which totals up the number of cards passing the
current requirements for completion of the bootcamp. This includes a blacklist of non-cohort
members.